### PR TITLE
Fix conversion bugs

### DIFF
--- a/src/admonitions/admonition.py
+++ b/src/admonitions/admonition.py
@@ -48,7 +48,7 @@ GH_CODEBLOCK_PATTERN = re.compile(
     flags=re.MULTILINE | re.DOTALL,
 )
 ALERT_BASIC_PATTERN = re.compile(
-    r"^> {,3}\[!(?P<type>note|tip|important|caution|warning)] *(?P<title>.*)\r?\n(?P<body>(?:> +.*\r?\n)+)",
+    r"^> {,3}\[!(?P<type>note|tip|important|caution|warning)] *(?P<title>.*)\r?\n(?P<body>(?:>.*\r?\n)+)",
     flags=re.IGNORECASE | re.MULTILINE,
 )
 """
@@ -58,7 +58,7 @@ Basic alert syntax pattern with capturing groups:
 - `body`: Alert body (GitHub & GitLab)
 """
 
-ALERT_BASIC_BODY_PREFIX = re.compile("^> ", re.MULTILINE)
+ALERT_BASIC_BODY_PREFIX = re.compile("^> ?", re.MULTILINE)
 
 ALERT_MULTILINE_PATTERN = re.compile(
     r"^>>> {,3}\[!(?P<type>note|tip|important|caution|warning)] *(?P<title>.*)\r?\n(?P<body>(?:.*\r?\n)+)>>>",

--- a/src/admonitions/admonition.py
+++ b/src/admonitions/admonition.py
@@ -44,7 +44,7 @@ from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 
 GH_CODEBLOCK_PATTERN = re.compile(
-    r"^```.*^```",
+    r"^```.*?^```",
     flags=re.MULTILINE | re.DOTALL,
 )
 ALERT_BASIC_PATTERN = re.compile(

--- a/tests/test_admonition.py
+++ b/tests/test_admonition.py
@@ -83,6 +83,40 @@ def test_alert_containing_codeblock_is_converted():
     )
 
 
+def test_alert_surrounded_by_codeblocks_is_converted():
+    # GIVEN
+    converter = AdmonitionConverter()
+    # WHEN
+    converted = converter.on_page_markdown(
+        "```text\ncode block\nbefore\n```\n\n> [!tip]\n> This is the alert.\n\n```\ncode block\nafter\n```\n",
+        page=None,
+        config=None,
+        files=None,
+    )
+    # THEN
+    assert (
+        converted
+        == '```text\ncode block\nbefore\n```\n\n!!! tip "Tip"\n    This is the alert.\n\n```\ncode block\nafter\n```\n'
+    )
+
+
+def test_alert_with_blank_lines():
+    # GIVEN
+    converter = AdmonitionConverter()
+    # WHEN
+    converted = converter.on_page_markdown(
+        "> [!note]\n> This is the first chapter.\n>\n> This is the second chapter.\n",
+        page=None,
+        config=None,
+        files=None,
+    )
+    # THEN
+    assert (
+        converted
+        == '!!! note "Note"\n    This is the first chapter.\n    \n    This is the second chapter.\n'
+    )
+
+
 def test_gl_overridden_title():
     # GIVEN
     converter = AdmonitionConverter()


### PR DESCRIPTION
This PR fixes two bugs introduced in #5 

1. my original `GH_CODEBLOCK_PATTERN` was greedy and therefore spanning over as many codeblocks as possible => skipped all alerts surrounded by codeblocks
2. the alert RegEx was expecting each line of the body to start with a whitespace, which is not necessarilly the case according to the specs

My PR contains three commits:

- new unit tests that reveal the bugs
- fix 1
- fix 2

Sorry for the inconvenience.

(I've learnt something here with the `.*?` RegEx modifier to make the pattern ungreedy; didn't know that before)